### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ TLDR; `curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master
     ```bash
     kubectl get pods -n knative-serving
     kubectl get pods -n kourier-system
-    kubectl get svc  -n kourier-ingress
+    kubectl get svc  -n kourier-system
     ```
 
 


### PR DESCRIPTION
The services live in the namespace kourier-system, not kourier-ingress. 

Running `kubectl get svc  -n kourier-ingress`
returns:
`No resources found in kourier-ingress namespace.`