### PR TITLE
Split the install of samples into their own scripts

### DIFF
--- a/02-serving.sh
+++ b/02-serving.sh
@@ -63,23 +63,4 @@ spec:
       targetPort: 8080
 EOF
 
-cat <<EOF | kubectl apply -f -
-apiVersion: serving.knative.dev/v1
-kind: Service
-metadata:
-  name: hello
-spec:
-  template:
-    spec:
-      containers:
-        - image: gcr.io/knative-samples/helloworld-go
-          ports:
-            - containerPort: 8080
-          env:
-            - name: TARGET
-              value: "Knative"
-EOF
-kubectl wait ksvc hello --all --timeout=-1s --for=condition=Ready
-SERVICE_URL=$(kubectl get ksvc hello -o jsonpath='{.status.url}')
-echo "The Knative Service hello endpoint is $SERVICE_URL"
-curl $SERVICE_URL
+kubectl wait deployment --all --timeout=-1s --for=condition=Available -n kourier-system

--- a/03-serving-samples.sh
+++ b/03-serving-samples.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+set -u
+
+cat <<EOF | kubectl apply -f -
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hello
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/knative-samples/helloworld-go
+          ports:
+            - containerPort: 8080
+          env:
+            - name: TARGET
+              value: "Knative"
+EOF
+
+kubectl wait ksvc hello --all --timeout=-1s --for=condition=Ready
+SERVICE_URL=$(kubectl get ksvc hello -o jsonpath='{.status.url}')
+echo "The Knative Service hello endpoint is $SERVICE_URL"
+curl $SERVICE_URL

--- a/04-eventing.sh
+++ b/04-eventing.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+KNATIVE_EVENTING_VERSION=${KNATIVE_EVENTING_VERSION:-0.21.1}
+NAMESPACE=${NAMESPACE:-default}
+set -u
+
+
+n=0
+until [ $n -ge 2 ]; do
+  kubectl apply -f https://github.com/knative/eventing/releases/download/v$KNATIVE_EVENTING_VERSION/eventing-crds.yaml && break
+  n=$[$n+1]
+  sleep 5
+done
+kubectl wait --for=condition=Established --all crd
+
+n=0
+until [ $n -ge 2 ]; do
+  kubectl apply -f https://github.com/knative/eventing/releases/download/v$KNATIVE_EVENTING_VERSION/eventing-core.yaml && break
+  n=$[$n+1]
+  sleep 5
+done
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-eventing
+
+n=0
+until [ $n -ge 2 ]; do
+  kubectl apply -f https://github.com/knative/eventing/releases/download/v$KNATIVE_EVENTING_VERSION/in-memory-channel.yaml && break
+  n=$[$n+1]
+  sleep 5
+done
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-eventing
+
+n=0
+until [ $n -ge 2 ]; do
+  kubectl apply -f https://github.com/knative/eventing/releases/download/v$KNATIVE_EVENTING_VERSION/mt-channel-broker.yaml && break
+  n=$[$n+1]
+  sleep 5
+done
+kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-eventing
+
+
+kubectl apply -f - <<EOF
+apiVersion: eventing.knative.dev/v1
+kind: broker
+metadata:
+ name: default
+ namespace: $NAMESPACE
+EOF
+
+sleep 3
+kubectl -n $NAMESPACE get broker default

--- a/05-eventing-samples.sh
+++ b/05-eventing-samples.sh
@@ -2,54 +2,9 @@
 
 set -eo pipefail
 
-KNATIVE_EVENTING_VERSION=${KNATIVE_EVENTING_VERSION:-0.21.1}
 NAMESPACE=${NAMESPACE:-default}
 set -u
 
-
-n=0
-until [ $n -ge 2 ]; do
-  kubectl apply -f https://github.com/knative/eventing/releases/download/v$KNATIVE_EVENTING_VERSION/eventing-crds.yaml && break
-  n=$[$n+1]
-  sleep 5
-done
-kubectl wait --for=condition=Established --all crd
-
-n=0
-until [ $n -ge 2 ]; do
-  kubectl apply -f https://github.com/knative/eventing/releases/download/v$KNATIVE_EVENTING_VERSION/eventing-core.yaml && break
-  n=$[$n+1]
-  sleep 5
-done
-kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-eventing
-
-n=0
-until [ $n -ge 2 ]; do
-  kubectl apply -f https://github.com/knative/eventing/releases/download/v$KNATIVE_EVENTING_VERSION/in-memory-channel.yaml && break
-  n=$[$n+1]
-  sleep 5
-done
-kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-eventing
-
-n=0
-until [ $n -ge 2 ]; do
-  kubectl apply -f https://github.com/knative/eventing/releases/download/v$KNATIVE_EVENTING_VERSION/mt-channel-broker.yaml && break
-  n=$[$n+1]
-  sleep 5
-done
-kubectl wait pod --timeout=-1s --for=condition=Ready -l '!job-name' -n knative-eventing
-
-
-kubectl apply -f - <<EOF
-apiVersion: eventing.knative.dev/v1
-kind: broker
-metadata:
- name: default
- namespace: $NAMESPACE
-EOF
-
-sleep 3
-kubectl -n $NAMESPACE get broker default
 
 kubectl -n $NAMESPACE apply -f - << EOF
 apiVersion: apps/v1
@@ -130,4 +85,3 @@ kubectl -n $NAMESPACE exec curl -- curl -s -v  "http://broker-ingress.knative-ev
 kubectl wait pod --timeout=-1s --for=condition=Ready -l app=hello-display -n $NAMESPACE
 
 kubectl -n $NAMESPACE logs -l app=hello-display --tail=100
-

--- a/demo.sh
+++ b/demo.sh
@@ -6,7 +6,9 @@ echo -e "\033[0;92m 🍿 Knative starting... \033[0m"
 STARTTIME=$(date +%s)
 curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/01-kind.sh | bash
 curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/02-serving.sh | bash
-curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/03-eventing.sh | bash
+curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/03-serving-samples.sh | bash
+curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/04-eventing.sh | bash
+curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/05-eventing-samples.sh | bash
 DURATION=$(($(date +%s) - $STARTTIME))
 echo "kubectl get ksvc,broker,trigger"
 kubectl -n default get ksvc,broker,trigger


### PR DESCRIPTION
Per our discussion, this PR splits out the samples to their own scripts. I've also updated `demo.sh` to include the new files, so the behavior curl'ing get.knok.dev is currently unchanged, since I wasn't sure which you wanted to be the default behavior. If we want it to not install the samples by default, we can remove those two lines from `demo.sh` if you like.