### PR TITLE
Make kind cluster name configurable

### DIFF
--- a/01-kind.sh
+++ b/01-kind.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 
 kindVersion=$(kind version);
 K8S_VERSION=${k8sVersion:-v1.20.2@sha256:15d3b5c4f521a84896ed1ead1b14e4774d02202d5c65ab68f30eeaf310a3b1a7}
+CLUSTER_NAME=${KIND_CLUSTER_NAME:-knative}
 
 if [[ $kindVersion =~ "v0.10." ]]
 then
@@ -14,19 +15,19 @@ else
 fi
 
 REPLY=continue
-KIND_EXIST="$(kind get clusters -q | grep knative || true)"
+KIND_EXIST="$(kind get clusters -q | grep ${CLUSTER_NAME} || true)"
 if [[ ${KIND_EXIST} ]] ; then
- read -p "Knative Cluster kind-knative already installed, delete and re-create? N/y: " REPLY </dev/tty
+ read -p "Knative Cluster kind-${CLUSTER_NAME} already installed, delete and re-create? N/y: " REPLY </dev/tty
 fi
 if [ "$REPLY" == "Y" ] || [ "$REPLY" == "y" ]; then
-  kind delete cluster --name knative
+  kind delete cluster --name ${CLUSTER_NAME}
 elif [ "$REPLY" == "N" ] || [ "$REPLY" == "n" ] || [ -z "$REPLY" ]; then
   echo "Installation skipped"
   exit 0
 fi
 
 KIND_CLUSTER=$(mktemp)
-cat <<EOF | kind create cluster --name knative --config=-
+cat <<EOF | kind create cluster --name ${CLUSTER_NAME} --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ TLDR; `curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master
 
 For more information installing or using kind checkout the docs https://kind.sigs.k8s.io/
 
+> **Note:** You can optionally specify a `kind` cluster name by setting the environment variable `KIND_CLUSTER_NAME`.
+
 ## Install Knative Serving
 
 TLDR; `curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/02-serving.sh | sh`


### PR DESCRIPTION
The old behavior, i.e. cluster name is "knative" is retained if env `$KIND_CLUSTER_NAME` is not specified.
Besides `kind` the `$KIND_CLUSTER_NAME` environment variable is also used in [google/ko](https://github.com/google/ko/blob/82cabb40bae577ce3bc016e5939fd85889538e8b/pkg/publish/kind/write.go#L32) which makes this behavior convenient.

Closes: #27 
Signed-off-by: Michael Gasch <mgasch@vmware.com>