### PR TITLE
rename broker to example-broker

### DIFF
--- a/04-eventing.sh
+++ b/04-eventing.sh
@@ -46,6 +46,7 @@ apiVersion: eventing.knative.dev/v1
 kind: broker
 metadata:
  name: ${BROKER_NAME}
+ namespace: ${NAMESPACE}
 EOF
 
 sleep 3

--- a/04-eventing.sh
+++ b/04-eventing.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 KNATIVE_EVENTING_VERSION=${KNATIVE_EVENTING_VERSION:-0.21.1}
 NAMESPACE=${NAMESPACE:-default}
-BROKER_NAME=${BROKER_NAME:example-broker}
+BROKER_NAME=${BROKER_NAME:-example-broker}
 set -u
 
 

--- a/04-eventing.sh
+++ b/04-eventing.sh
@@ -50,4 +50,4 @@ metadata:
 EOF
 
 sleep 3
-kubectl get broker ${BROKER_NAME}
+kubectl -n ${NAMESPACE} get broker ${BROKER_NAME}

--- a/04-eventing.sh
+++ b/04-eventing.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 
 KNATIVE_EVENTING_VERSION=${KNATIVE_EVENTING_VERSION:-0.21.1}
 NAMESPACE=${NAMESPACE:-default}
+BROKER_NAME=${BROKER_NAME:example-broker}
 set -u
 
 
@@ -44,9 +45,8 @@ kubectl apply -f - <<EOF
 apiVersion: eventing.knative.dev/v1
 kind: broker
 metadata:
- name: default
- namespace: $NAMESPACE
+ name: ${BROKER_NAME}
 EOF
 
 sleep 3
-kubectl -n $NAMESPACE get broker default
+kubectl get broker ${BROKER_NAME}

--- a/05-eventing-samples.sh
+++ b/05-eventing-samples.sh
@@ -3,6 +3,7 @@
 set -eo pipefail
 
 NAMESPACE=${NAMESPACE:-default}
+BROKER_NAME=${BROKER_NAME:-example-broker}
 set -u
 
 
@@ -45,7 +46,7 @@ kind: Trigger
 metadata:
   name: hello-display
 spec:
-  broker: default
+  broker: $BROKER_NAME
   filter:
     attributes:
       type: greeting
@@ -73,7 +74,7 @@ spec:
 EOF
 kubectl wait -n $NAMESPACE pod curl --timeout=-1s --for=condition=Ready
 
-kubectl -n $NAMESPACE exec curl -- curl -s -v  "http://broker-ingress.knative-eventing.svc.cluster.local/$NAMESPACE/default" \
+kubectl -n $NAMESPACE exec curl -- curl -s -v  "http://broker-ingress.knative-eventing.svc.cluster.local/$NAMESPACE/$BROKER_NAME" \
   -X POST \
   -H "Ce-Id: say-hello" \
   -H "Ce-Specversion: 1.0" \

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ TLDR; `curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master
     apiVersion: eventing.knative.dev/v1
     kind: broker
     metadata:
-      name: default
+      name: example-broker
       namespace: $NAMESPACE
     EOF
     ```
@@ -289,8 +289,8 @@ TLDR; `curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master
 
 - Shoud print the address of the broker
     ```
-    NAME      URL                                                                        AGE   READY   REASON
-    default   http://broker-ingress.knative-eventing.svc.cluster.local/default/default   47s   True
+    NAME             URL                                                                               AGE   READY   REASON
+    example-broker   http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker   47s   True
     ```
 
 - To deploy the `hello-display` consumer to your cluster, run the following command:
@@ -338,7 +338,7 @@ TLDR; `curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master
     metadata:
       name: hello-display
     spec:
-      broker: default
+      broker: example-broker
       filter:
         attributes:
           type: greeting
@@ -373,7 +373,7 @@ TLDR; `curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master
 
 - Send a Cloud Event usnig `curl` pod created in the previous step.
     ```bash
-    kubectl -n $NAMESPACE exec curl -- curl -s -v  "http://broker-ingress.knative-eventing.svc.cluster.local/$NAMESPACE/default" \
+    kubectl -n $NAMESPACE exec curl -- curl -s -v  "http://broker-ingress.knative-eventing.svc.cluster.local/$NAMESPACE/example-broker" \
       -X POST \
       -H "Ce-Id: say-hello" \
       -H "Ce-Specversion: 1.0" \


### PR DESCRIPTION
Folks gave feedback that using `default` for the name of the broker used in the tutorial was confusing.

Changing the name to `example-broker`